### PR TITLE
Extract LLM fetch into resilient llmClient with timeout, retries and safe logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # GigaTranslatorAgency
+
+Минимальный модуль для перевода чанков текста через LLM API c production-защитами:
+
+- `src/translateChunk.js` — формирует промпт и вызывает клиент.
+- `src/llmClient.js` — делает HTTP-вызов с timeout, retries, exponential backoff + jitter, `Retry-After` и безопасным логированием.
+
+## Экспорт
+
+```js
+import { translateChunk, requestLlm } from './src/index.js';
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "giga-translator-agency",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { llmClient, requestLlm } from './llmClient.js';
+export { translateChunk } from './translateChunk.js';

--- a/src/llmClient.js
+++ b/src/llmClient.js
@@ -1,0 +1,190 @@
+const DEFAULT_TIMEOUT_MS = 45_000;
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_BACKOFF_MS = 500;
+const DEFAULT_MAX_BACKOFF_MS = 10_000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryAfterMs(retryAfterHeader) {
+  if (!retryAfterHeader) {
+    return null;
+  }
+
+  const seconds = Number(retryAfterHeader);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const parsedDate = Date.parse(retryAfterHeader);
+  if (!Number.isNaN(parsedDate)) {
+    const delta = parsedDate - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+
+  return null;
+}
+
+function computeBackoffWithJitter(attempt, baseBackoffMs, maxBackoffMs) {
+  const exponential = Math.min(maxBackoffMs, baseBackoffMs * 2 ** (attempt - 1));
+  const jitter = Math.floor(Math.random() * Math.min(1_000, exponential * 0.3));
+  return exponential + jitter;
+}
+
+function isRetriableResponse(status) {
+  return status === 429 || status >= 500;
+}
+
+function isRetriableError(error) {
+  if (!error) {
+    return false;
+  }
+
+  if (error.name === 'AbortError') {
+    return true;
+  }
+
+  // Typical fetch/network errors.
+  return error instanceof TypeError;
+}
+
+function safeLog(logger, level, payload) {
+  const fn = logger?.[level];
+  if (typeof fn === 'function') {
+    fn(payload);
+  }
+}
+
+function getRequestId(response) {
+  return (
+    response.headers.get('x-request-id') ||
+    response.headers.get('request-id') ||
+    response.headers.get('x-amzn-requestid') ||
+    (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `req_${Date.now()}_${Math.random().toString(16).slice(2)}`)
+  );
+}
+
+/**
+ * Performs a POST request to the LLM provider with timeout, retries and safe operational logging.
+ */
+export async function requestLlm({
+  url,
+  apiKey,
+  payload,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  maxRetries = DEFAULT_MAX_RETRIES,
+  baseBackoffMs = DEFAULT_BASE_BACKOFF_MS,
+  maxBackoffMs = DEFAULT_MAX_BACKOFF_MS,
+  fetchImpl = fetch,
+  logger = console,
+}) {
+  if (!url) {
+    throw new Error('requestLlm: url is required');
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('requestLlm: payload must be an object');
+  }
+
+  const requestBody = JSON.stringify(payload);
+  const inputBytes = Buffer.byteLength(requestBody, 'utf8');
+
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
+    const startedAt = Date.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+        },
+        body: requestBody,
+        signal: controller.signal,
+      });
+
+      const requestId = getRequestId(response);
+      const responseText = await response.text();
+      const outputBytes = Buffer.byteLength(responseText, 'utf8');
+      const durationMs = Date.now() - startedAt;
+
+      safeLog(logger, response.ok ? 'info' : 'warn', {
+        event: 'llm_request',
+        attempt,
+        request_id: requestId,
+        status: response.status,
+        duration_ms: durationMs,
+        input_bytes: inputBytes,
+        output_bytes: outputBytes,
+      });
+
+      if (response.ok) {
+        return {
+          requestId,
+          status: response.status,
+          durationMs,
+          bodyText: responseText,
+        };
+      }
+
+      if (!isRetriableResponse(response.status) || attempt > maxRetries) {
+        const error = new Error(`LLM request failed with status ${response.status}`);
+        error.status = response.status;
+        error.requestId = requestId;
+        error.responseBody = responseText;
+        throw error;
+      }
+
+      const retryAfterHeader = response.headers.get('retry-after');
+      const retryAfterMs = parseRetryAfterMs(retryAfterHeader);
+      const delayMs = retryAfterMs ?? computeBackoffWithJitter(attempt, baseBackoffMs, maxBackoffMs);
+
+      safeLog(logger, 'warn', {
+        event: 'llm_retry_scheduled',
+        attempt,
+        request_id: requestId,
+        status: response.status,
+        retry_in_ms: delayMs,
+      });
+
+      await sleep(delayMs);
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+
+      safeLog(logger, 'warn', {
+        event: 'llm_request_error',
+        attempt,
+        request_id: error?.requestId,
+        status: error?.status,
+        duration_ms: durationMs,
+        input_bytes: inputBytes,
+        output_bytes: 0,
+        error_name: error?.name,
+        error_message: error?.message,
+      });
+
+      if (!isRetriableError(error) || attempt > maxRetries) {
+        throw error;
+      }
+
+      lastError = error;
+      const delayMs = computeBackoffWithJitter(attempt, baseBackoffMs, maxBackoffMs);
+      await sleep(delayMs);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw lastError ?? new Error('LLM request failed after retries');
+}
+
+export const llmClient = {
+  requestLlm,
+};

--- a/src/translateChunk.js
+++ b/src/translateChunk.js
@@ -1,0 +1,61 @@
+import { requestLlm } from './llmClient.js';
+
+/**
+ * Translates a single chunk using an LLM endpoint.
+ */
+export async function translateChunk({
+  chunk,
+  sourceLang,
+  targetLang,
+  endpoint,
+  apiKey,
+  model,
+  timeoutMs,
+  maxRetries,
+  logger,
+}) {
+  if (!chunk || typeof chunk !== 'string') {
+    throw new Error('translateChunk: chunk must be a non-empty string');
+  }
+
+  const payload = {
+    model,
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a professional translator. Keep meaning and style accurate.',
+      },
+      {
+        role: 'user',
+        content: `Translate from ${sourceLang} to ${targetLang}:\n\n${chunk}`,
+      },
+    ],
+    temperature: 0.2,
+  };
+
+  const response = await requestLlm({
+    url: endpoint,
+    apiKey,
+    payload,
+    timeoutMs,
+    maxRetries,
+    logger,
+  });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(response.bodyText);
+  } catch {
+    throw new Error('translateChunk: LLM returned invalid JSON');
+  }
+
+  const translatedText = parsed?.choices?.[0]?.message?.content?.trim();
+  if (!translatedText) {
+    throw new Error('translateChunk: LLM response does not contain translated text');
+  }
+
+  return {
+    requestId: response.requestId,
+    text: translatedText,
+  };
+}


### PR DESCRIPTION
### Motivation
- Централизовать HTTP-вызовы к LLM в одном модуле для повторного использования и упрощения отказоустойчивости. 
- Добавить пер-запрос тайм-ауты и обработку прерывания через `AbortController` чтобы избежать зависших тел запросов. 
- Реализовать автоматические повторы с backoff и обработкой `Retry-After` для корректной работы при перегрузке/ошибках сети. 
- Логировать только операционную мета-информацию (`request_id`, длительность, статус, вход/выход в байтах) без утечки промпратов и ключей.

### Description
- Добавлен новый модуль `src/llmClient.js` с экспортируемой функцией `requestLlm` реализующей POST-вызов через `fetch` с конфигурируемым `timeoutMs`, `maxRetries`, `baseBackoffMs` и `maxBackoffMs`.
- В `requestLlm` реализован пер-аттемпт `AbortController` тайм-аут, retry для `429`/`5xx` и сетевых ошибок, exponential backoff с jitter и приоритетом значения из `Retry-After` (поддержка секунд и HTTP-date).
- Добавлено безопасное структурированное логирование через `safeLog` (логируются `request_id`, `status`, `duration_ms`, `input_bytes`, `output_bytes`, `attempt`, события), без логирования содержимого запросов/ключей.
- Рефактор `translateChunk` в `src/translateChunk.js` теперь формирует `payload` и вызывает `requestLlm`, парсит `response.bodyText` и возвращает `{ requestId, text }`; добавлен экспорт через `src/index.js` и небольшое обновление `README.md` и `package.json`.

### Testing
- Проверена синтаксическая корректность модулей командой `node --check src/llmClient.js`, `node --check src/translateChunk.js` и `node --check src/index.js`, и проверки завершились успешно. 
- Проверена загрузка экспорта командой `node -e "import('./src/index.js').then(m=>console.log(Object.keys(m).join(',')))"`, которая вернула ожидаемые экспорты. 
- Нет интеграционных сетевых тестов в этом PR, поведение сетевых повторов и `Retry-After` следует валидировать в окружении с реальным LLM или с мок-сервером при дальнейшем тестировании.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885eb6c23c8333a54ef1328347495c)