### PR TITLE
Add structured translation error codes and troubleshooting CTAs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,131 @@
+const inputEl = document.getElementById('input');
+const outputEl = document.getElementById('output');
+const statusEl = document.getElementById('status');
+const translateBtn = document.getElementById('translateBtn');
+const troubleshootingEl = document.getElementById('troubleshooting');
+const retryBtn = document.getElementById('retryBtn');
+const checkKeyBtn = document.getElementById('checkKeyBtn');
+const reduceTextBtn = document.getElementById('reduceTextBtn');
+
+const ERROR_META = {
+  NETWORK: {
+    message: 'Похоже, нет соединения с сервером. Проверьте интернет и попробуйте снова.',
+    ctas: ['retry'],
+  },
+  TIMEOUT: {
+    message: 'Сервис отвечает слишком долго. Обычно помогает повторить запрос.',
+    ctas: ['retry', 'reduceText'],
+  },
+  RATE_LIMIT: {
+    message: 'Достигнут лимит запросов. Подождите немного или уменьшите объём текста.',
+    ctas: ['retry', 'reduceText'],
+  },
+  INVALID_KEY: {
+    message: 'API key не принят. Проверьте ключ и права доступа.',
+    ctas: ['checkKey'],
+  },
+  PROVIDER_ERROR: {
+    message: 'Провайдер перевода временно недоступен. Повторите попытку через минуту.',
+    ctas: ['retry'],
+  },
+  UNKNOWN: {
+    message: 'Произошла непредвиденная ошибка. Попробуйте повторить запрос.',
+    ctas: ['retry'],
+  },
+};
+
+let lastPayload = null;
+
+function setStatus(text, isError = false) {
+  statusEl.textContent = text;
+  statusEl.classList.toggle('status-error', isError);
+}
+
+function setOutput(text = '') {
+  outputEl.textContent = text;
+}
+
+function toggleTroubleshooting(show, ctaKeys = []) {
+  troubleshootingEl.classList.toggle('show', show);
+  retryBtn.hidden = !ctaKeys.includes('retry');
+  checkKeyBtn.hidden = !ctaKeys.includes('checkKey');
+  reduceTextBtn.hidden = !ctaKeys.includes('reduceText');
+}
+
+function classifyError(payload) {
+  if (!payload) {
+    return ERROR_META.UNKNOWN;
+  }
+
+  const normalizedCode = (payload.errorCode || payload.type || '').toUpperCase();
+
+  if (normalizedCode in ERROR_META) {
+    return ERROR_META[normalizedCode];
+  }
+
+  return ERROR_META.UNKNOWN;
+}
+
+async function performTranslate(payload) {
+  setStatus('Переводим...');
+  toggleTroubleshooting(false);
+
+  try {
+    const response = await fetch('/api/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const meta = classifyError(data);
+      const hintSuffix = data.hint ? ` ${data.hint}` : '';
+      setStatus(`${meta.message}${hintSuffix}`, true);
+      toggleTroubleshooting(true, meta.ctas);
+      return;
+    }
+
+    setStatus('Готово.');
+    setOutput(data.translation || '');
+  } catch (_err) {
+    const meta = ERROR_META.NETWORK;
+    setStatus(meta.message, true);
+    toggleTroubleshooting(true, meta.ctas);
+  }
+}
+
+translateBtn.addEventListener('click', async () => {
+  const text = inputEl.value.trim();
+
+  if (!text) {
+    setStatus('Введите текст для перевода.', true);
+    toggleTroubleshooting(false);
+    return;
+  }
+
+  lastPayload = { text };
+  await performTranslate(lastPayload);
+});
+
+retryBtn.addEventListener('click', async () => {
+  if (lastPayload) {
+    await performTranslate(lastPayload);
+  }
+});
+
+checkKeyBtn.addEventListener('click', () => {
+  setStatus('Проверьте API key в настройках сервера: значение, срок действия и права доступа.', false);
+});
+
+reduceTextBtn.addEventListener('click', () => {
+  const current = inputEl.value.trim();
+  if (current.length <= 500) {
+    setStatus('Текст уже достаточно короткий. Можно попробовать повторить перевод.', false);
+    return;
+  }
+
+  inputEl.value = `${current.slice(0, 500)}...`;
+  setStatus('Сократили текст до 500 символов. Попробуйте отправить снова.', false);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GigaTranslatorAgency</title>
+    <style>
+      :root {
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      }
+      body {
+        margin: 2rem;
+        max-width: 720px;
+      }
+      textarea {
+        width: 100%;
+        min-height: 120px;
+        margin-bottom: 0.75rem;
+      }
+      #status {
+        min-height: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      .status-error {
+        color: #b42318;
+      }
+      #troubleshooting {
+        display: none;
+        border: 1px solid #e4e7ec;
+        border-radius: 8px;
+        padding: 0.6rem 0.75rem;
+        background: #f9fafb;
+        font-size: 0.92rem;
+        margin-bottom: 1rem;
+      }
+      #troubleshooting.show {
+        display: block;
+      }
+      #troubleshooting .title {
+        font-weight: 600;
+        margin-bottom: 0.35rem;
+      }
+      .cta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .cta-row button {
+        border: 1px solid #d0d5dd;
+        background: white;
+        border-radius: 6px;
+        padding: 0.35rem 0.65rem;
+        cursor: pointer;
+      }
+      #output {
+        border: 1px solid #e4e7ec;
+        border-radius: 8px;
+        min-height: 100px;
+        padding: 0.75rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>GigaTranslatorAgency</h1>
+
+    <textarea id="input" placeholder="Введите текст для перевода"></textarea>
+    <button id="translateBtn">Перевести</button>
+
+    <p id="status" role="status" aria-live="polite"></p>
+
+    <div id="troubleshooting" aria-live="polite">
+      <div class="title">Что можно сделать сейчас:</div>
+      <div class="cta-row">
+        <button id="retryBtn" type="button">Повторить</button>
+        <button id="checkKeyBtn" type="button">Проверить API key</button>
+        <button id="reduceTextBtn" type="button">Уменьшить объём текста</button>
+      </div>
+    </div>
+
+    <div id="output"></div>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+class AppError extends Error {
+  constructor(message, status, errorCode, hint) {
+    super(message);
+    this.status = status;
+    this.errorCode = errorCode;
+    this.hint = hint;
+  }
+}
+
+function mapProviderError(error) {
+  if (error.name === 'AbortError') {
+    return new AppError('Provider timeout', 504, 'TIMEOUT', 'Попробуйте отправить запрос ещё раз или сократите текст.');
+  }
+
+  if (error.code === 'ECONNREFUSED' || error.code === 'ENOTFOUND') {
+    return new AppError('Network issue', 503, 'NETWORK', 'Нет связи с провайдером перевода.');
+  }
+
+  if (error.status === 429) {
+    return new AppError('Rate limit exceeded', 429, 'RATE_LIMIT', 'Подождите 30-60 секунд перед следующим запросом.');
+  }
+
+  if (error.status === 401 || error.status === 403) {
+    return new AppError('Invalid API key', 401, 'INVALID_KEY', 'Проверьте API key и его права доступа.');
+  }
+
+  return new AppError('Provider error', 502, 'PROVIDER_ERROR', 'Временная ошибка на стороне провайдера.');
+}
+
+// Демонстрационный переводчик: замените интеграцией с реальным API.
+async function translateWithProvider(text) {
+  const simulated = process.env.SIMULATE_ERROR;
+  if (simulated === 'timeout') {
+    const err = new Error('Request timed out');
+    err.name = 'AbortError';
+    throw err;
+  }
+  if (simulated === 'network') {
+    const err = new Error('No route to host');
+    err.code = 'ENOTFOUND';
+    throw err;
+  }
+  if (simulated === 'rate_limit') {
+    const err = new Error('Too many requests');
+    err.status = 429;
+    throw err;
+  }
+  if (simulated === 'invalid_key') {
+    const err = new Error('Unauthorized');
+    err.status = 401;
+    throw err;
+  }
+  if (simulated === 'provider') {
+    throw new Error('Provider unavailable');
+  }
+
+  return text.split('').reverse().join('');
+}
+
+app.post('/api/translate', async (req, res) => {
+  const { text } = req.body || {};
+
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({
+      error: 'Invalid request payload',
+      errorCode: 'BAD_REQUEST',
+      hint: 'Поле text обязательно и должно быть строкой.',
+    });
+  }
+
+  try {
+    const translation = await translateWithProvider(text);
+    return res.json({ translation });
+  } catch (error) {
+    const mapped = mapProviderError(error);
+    return res.status(mapped.status).json({
+      error: mapped.message,
+      errorCode: mapped.errorCode,
+      hint: mapped.hint,
+    });
+  }
+});
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server started on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
### Motivation
- Provide structured, machine-readable error responses (`errorCode`, `hint`) from the translation API so clients can react programmatically.
- Surface friendly, localized error messages in the UI so users understand what went wrong (network, timeout, rate limit, invalid key, provider error).
- Give immediate, actionable CTAs in the UI (retry, check API key, reduce text) and a compact troubleshooting block to reduce support friction.

### Description
- Implemented structured error handling on the server by adding `AppError`, `mapProviderError`, and returning JSON with `errorCode` and `hint` for `TIMEOUT`, `NETWORK`, `RATE_LIMIT`, `INVALID_KEY`, `PROVIDER_ERROR`, and `BAD_REQUEST` in `server.js`.
- Added a demo `translateWithProvider` in `server.js` that can simulate different error conditions via `SIMULATE_ERROR` for local testing.
- Implemented frontend error typing and friendly messages in `public/app.js` with `ERROR_META`, `classifyError`, dynamic CTA visibility, and handlers for `retry`, `checkKey`, and `reduceText` actions.
- Added a compact troubleshooting UI block and styling under the status area in `public/index.html` that shows context-aware CTAs and preserves accessibility attributes (`role="status"`, `aria-live`).

### Testing
- Ran syntax checks with `node --check server.js` which succeeded.
- Ran syntax checks with `node --check public/app.js` which succeeded.
- Served the static UI with `python3 -m http.server 3000 --directory /workspace/GigaTranslatorAgency/public` and captured a visual smoke-check screenshot using Playwright which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885f44c48c8333a7e3133109e9f7e2)